### PR TITLE
Remove comments from <head> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,12 @@
 <head>
     <title>BTV: Who's My Councillor?</title>
     
-    /* Standard search engine metas */
     <meta charset="UTF-8">
     <meta name="description" content="Enter your address to find your City Ward & District councillors">
     <meta name="keywords" content="ward, wards, district, districts, council, councillor, councillors, burlington, vt, church, street, vermont, btv, queen, city">
     <meta name="author" content="BTV dev community">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
-    /* Social sharing metas */
+   
     <meta property="og:title" content="BTV: Who's My Councillor?">
     <meta property="og:description" content="Enter your address to find your City Ward & District councillors">
     <meta property="og:image" content="https://property.burlingtonvt.gov/Assets/Images/CitySeal.png">


### PR DESCRIPTION
Looks like GitHub pages doesn't like comments in the head tag, they display when I resize the screen - sorry about that!